### PR TITLE
fix(quiz): shared-quiz crash + stray underline/bold markers

### DIFF
--- a/app/Http/Controllers/CustomQuizController.php
+++ b/app/Http/Controllers/CustomQuizController.php
@@ -163,20 +163,31 @@ class CustomQuizController extends Controller
   }
 
   /**
-   * Wraps $inner in an open/close marker, but keeps any trailing newline(s)
-   * outside the marker instead of inside it. Some rich-text editors nest a
-   * block element (p/div/li) *inside* an inline bold/underline/color node
-   * instead of the reverse - when that happens $inner already ends with the
-   * "\n" the block tag appended, and wrapping it verbatim would produce
-   * "**text\n**" (closing marker glued to the start of the next line)
-   * instead of the intended "**text**\n".
+   * Wraps $inner in an open/close marker, but keeps every newline - leading,
+   * trailing, or in between - outside the marker instead of splitting it in
+   * half. Some rich-text editors nest a block element (p/div/li) *inside* an
+   * inline bold/underline/color node instead of the reverse, and when that
+   * block element spans *multiple* paragraphs/lines, $inner ends up with a
+   * "\n" in the middle (not just at the end). Wrapping the whole thing
+   * verbatim would produce "<u>line one\nline two</u>" - a single marker
+   * pair straddling two lines - which then gets torn apart into "<u>" stuck
+   * on the end of one option and "</u>" stuck on the start of the next once
+   * the markdown is split into lines, leaving both unmatched and visible as
+   * literal text. Wrapping each newline-delimited segment separately keeps
+   * every marker pair on its own line instead.
    */
   private function wrapMarker(string $inner, string $open, string $close): string
   {
-    if (preg_match('/^(.*?)(\n*)$/us', $inner, $m)) {
-      return $open . $m[1] . $close . $m[2];
+    $segments = preg_split('/(\n+)/u', $inner, -1, PREG_SPLIT_DELIM_CAPTURE);
+    $result = '';
+    foreach ($segments as $segment) {
+      // Odd-indexed pieces from PREG_SPLIT_DELIM_CAPTURE are the "\n+"
+      // delimiters themselves - pass them through untouched.
+      $result .= ($segment === '' || preg_match('/^\n+$/u', $segment))
+        ? $segment
+        : $open . $segment . $close;
     }
-    return $open . $inner . $close;
+    return $result;
   }
 
   private function hasMarkedColor(\DOMElement $node): bool

--- a/app/Http/Controllers/QuizController.php
+++ b/app/Http/Controllers/QuizController.php
@@ -262,6 +262,11 @@ class QuizController extends Controller
         'difficulty' => $quizSet->difficulty,
         'question_count' => $quizSet->question_count,
         'status' => 'completed',
+        'questions' => $questionsById->map(fn($q) => [
+          'id' => $q['id'],
+          'question' => $q['question'],
+          'options' => $q['options'],
+        ])->values(),
         'result' => [
           'score' => $play->score,
           'total' => $quizSet->question_count,

--- a/app/Services/LocalQuizContentParser.php
+++ b/app/Services/LocalQuizContentParser.php
@@ -278,6 +278,12 @@ class LocalQuizContentParser
     $text = preg_replace('/<u>(.+?)<\/u>/us', '$1', $text);
     $text = preg_replace('/<mark>(.+?)<\/mark>/us', '$1', $text);
     $text = preg_replace('/__(.+?)__/us', '$1', $text);
+    // Safety net: a marker pair split across two options by an upstream
+    // extraction quirk (e.g. an underline spanning a paragraph/line break)
+    // leaves one half unmatched here - strip any leftover lone open/close
+    // tag rather than showing it as literal text to quiz-takers.
+    $text = preg_replace('/<\/?u>|<\/?mark>/u', '', $text);
+    $text = preg_replace('/\*\*|__/u', '', $text);
     return $text;
   }
 

--- a/app/Services/QuizDocumentExtractionService.php
+++ b/app/Services/QuizDocumentExtractionService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use Illuminate\Http\UploadedFile;
 use PhpOffice\PhpWord\Element\Text;
+use PhpOffice\PhpWord\Element\TextBreak;
 use PhpOffice\PhpWord\Element\TextRun;
 use PhpOffice\PhpWord\IOFactory;
 use Smalot\PdfParser\Parser as PdfParser;
@@ -76,6 +77,14 @@ class QuizDocumentExtractionService
 
   private function elementToMarkdown($element): ?string
   {
+    // A soft line break (Shift+Enter) inside a single paragraph - if left
+    // unhandled it silently disappears (see the catch-all below), which
+    // glues two options that were only visually separated by this break
+    // into one run-on line and corrupts label/mark parsing downstream.
+    if ($element instanceof TextBreak) {
+      return "\n";
+    }
+
     if ($element instanceof TextRun) {
       $parts = [];
       foreach ($element->getElements() as $child) {


### PR DESCRIPTION
## Summary
- `QuizController::join()` omitted `questions` when a shared quiz link was already completed, crashing the Next.js result screen with `Cannot read properties of undefined (reading 'map')` whenever someone opened a shared quiz they'd already finished.
- Fixed a class of bug where an underline/bold mark spanning a paragraph/line boundary (dropped docx line break, or a rich-text editor nesting a block element inside an inline mark) produced literal `<u>`/`</u>` text visible to quiz-takers instead of real formatting.

## Changes
- `app/Http/Controllers/QuizController.php`: include `questions` in the completed-status branch of `join()`.
- `app/Services/QuizDocumentExtractionService.php`: stop dropping docx soft line breaks (`TextBreak`).
- `app/Http/Controllers/CustomQuizController.php`: `wrapMarker` now wraps each line of multi-line inner content separately instead of only handling a trailing newline.
- `app/Services/LocalQuizContentParser.php`: strip any still-unmatched marker as a safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)