### PR TITLE
fix(quiz): strip stray markers from AI parsing fallback too

### DIFF
--- a/app/Http/Controllers/CustomQuizController.php
+++ b/app/Http/Controllers/CustomQuizController.php
@@ -163,20 +163,31 @@ class CustomQuizController extends Controller
   }
 
   /**
-   * Wraps $inner in an open/close marker, but keeps any trailing newline(s)
-   * outside the marker instead of inside it. Some rich-text editors nest a
-   * block element (p/div/li) *inside* an inline bold/underline/color node
-   * instead of the reverse - when that happens $inner already ends with the
-   * "\n" the block tag appended, and wrapping it verbatim would produce
-   * "**text\n**" (closing marker glued to the start of the next line)
-   * instead of the intended "**text**\n".
+   * Wraps $inner in an open/close marker, but keeps every newline - leading,
+   * trailing, or in between - outside the marker instead of splitting it in
+   * half. Some rich-text editors nest a block element (p/div/li) *inside* an
+   * inline bold/underline/color node instead of the reverse, and when that
+   * block element spans *multiple* paragraphs/lines, $inner ends up with a
+   * "\n" in the middle (not just at the end). Wrapping the whole thing
+   * verbatim would produce "<u>line one\nline two</u>" - a single marker
+   * pair straddling two lines - which then gets torn apart into "<u>" stuck
+   * on the end of one option and "</u>" stuck on the start of the next once
+   * the markdown is split into lines, leaving both unmatched and visible as
+   * literal text. Wrapping each newline-delimited segment separately keeps
+   * every marker pair on its own line instead.
    */
   private function wrapMarker(string $inner, string $open, string $close): string
   {
-    if (preg_match('/^(.*?)(\n*)$/us', $inner, $m)) {
-      return $open . $m[1] . $close . $m[2];
+    $segments = preg_split('/(\n+)/u', $inner, -1, PREG_SPLIT_DELIM_CAPTURE);
+    $result = '';
+    foreach ($segments as $segment) {
+      // Odd-indexed pieces from PREG_SPLIT_DELIM_CAPTURE are the "\n+"
+      // delimiters themselves - pass them through untouched.
+      $result .= ($segment === '' || preg_match('/^\n+$/u', $segment))
+        ? $segment
+        : $open . $segment . $close;
     }
-    return $open . $inner . $close;
+    return $result;
   }
 
   private function hasMarkedColor(\DOMElement $node): bool

--- a/app/Http/Controllers/QuizController.php
+++ b/app/Http/Controllers/QuizController.php
@@ -262,6 +262,11 @@ class QuizController extends Controller
         'difficulty' => $quizSet->difficulty,
         'question_count' => $quizSet->question_count,
         'status' => 'completed',
+        'questions' => $questionsById->map(fn($q) => [
+          'id' => $q['id'],
+          'question' => $q['question'],
+          'options' => $q['options'],
+        ])->values(),
         'result' => [
           'score' => $play->score,
           'total' => $quizSet->question_count,

--- a/app/Services/CustomQuizParsingService.php
+++ b/app/Services/CustomQuizParsingService.php
@@ -152,7 +152,7 @@ PROMPT;
         continue;
       }
 
-      $options = array_values(array_map('strval', $q['options']));
+      $options = array_values(array_map(fn($o) => QuizMarkupStripper::strip((string) $o), $q['options']));
       $answerIndex = array_search($q['answer'], ['A', 'B', 'C', 'D'], true);
       if ($answerIndex >= count($options)) {
         continue; // "answer" points past the (fewer than 4) options actually given
@@ -163,10 +163,15 @@ PROMPT;
 
       $questions[] = [
         'id' => count($questions) + 1,
-        'question' => (string) $q['question'],
+        // The prompt asks the model to already strip markup from its JSON
+        // output, but it isn't perfectly reliable about it (particularly
+        // for a marker left unbalanced by an upstream extraction quirk -
+        // see QuizMarkupStripper) - run the same safety net here too rather
+        // than trusting the model's own cleanup.
+        'question' => QuizMarkupStripper::strip((string) $q['question']),
         'options' => $options,
         'answer' => (string) $q['answer'],
-        'explanation' => isset($q['explanation']) ? (string) $q['explanation'] : '',
+        'explanation' => isset($q['explanation']) ? QuizMarkupStripper::strip((string) $q['explanation']) : '',
       ];
     }
 

--- a/app/Services/LocalQuizContentParser.php
+++ b/app/Services/LocalQuizContentParser.php
@@ -278,6 +278,12 @@ class LocalQuizContentParser
     $text = preg_replace('/<u>(.+?)<\/u>/us', '$1', $text);
     $text = preg_replace('/<mark>(.+?)<\/mark>/us', '$1', $text);
     $text = preg_replace('/__(.+?)__/us', '$1', $text);
+    // Safety net: a marker pair split across two options by an upstream
+    // extraction quirk (e.g. an underline spanning a paragraph/line break)
+    // leaves one half unmatched here - strip any leftover lone open/close
+    // tag rather than showing it as literal text to quiz-takers.
+    $text = preg_replace('/<\/?u>|<\/?mark>/u', '', $text);
+    $text = preg_replace('/\*\*|__/u', '', $text);
     return $text;
   }
 

--- a/app/Services/LocalQuizContentParser.php
+++ b/app/Services/LocalQuizContentParser.php
@@ -274,17 +274,7 @@ class LocalQuizContentParser
 
   private function stripMarks(string $text): string
   {
-    $text = preg_replace('/\*\*(.+?)\*\*/us', '$1', $text);
-    $text = preg_replace('/<u>(.+?)<\/u>/us', '$1', $text);
-    $text = preg_replace('/<mark>(.+?)<\/mark>/us', '$1', $text);
-    $text = preg_replace('/__(.+?)__/us', '$1', $text);
-    // Safety net: a marker pair split across two options by an upstream
-    // extraction quirk (e.g. an underline spanning a paragraph/line break)
-    // leaves one half unmatched here - strip any leftover lone open/close
-    // tag rather than showing it as literal text to quiz-takers.
-    $text = preg_replace('/<\/?u>|<\/?mark>/u', '', $text);
-    $text = preg_replace('/\*\*|__/u', '', $text);
-    return $text;
+    return QuizMarkupStripper::strip($text);
   }
 
   /**

--- a/app/Services/QuizDocumentExtractionService.php
+++ b/app/Services/QuizDocumentExtractionService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use Illuminate\Http\UploadedFile;
 use PhpOffice\PhpWord\Element\Text;
+use PhpOffice\PhpWord\Element\TextBreak;
 use PhpOffice\PhpWord\Element\TextRun;
 use PhpOffice\PhpWord\IOFactory;
 use Smalot\PdfParser\Parser as PdfParser;
@@ -76,6 +77,14 @@ class QuizDocumentExtractionService
 
   private function elementToMarkdown($element): ?string
   {
+    // A soft line break (Shift+Enter) inside a single paragraph - if left
+    // unhandled it silently disappears (see the catch-all below), which
+    // glues two options that were only visually separated by this break
+    // into one run-on line and corrupts label/mark parsing downstream.
+    if ($element instanceof TextBreak) {
+      return "\n";
+    }
+
     if ($element instanceof TextRun) {
       $parts = [];
       foreach ($element->getElements() as $child) {

--- a/app/Services/QuizMarkupStripper.php
+++ b/app/Services/QuizMarkupStripper.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Services;
+
+/**
+ * Strips the "**bold**"/<u>underline</u>/<mark>color</mark> answer-marking
+ * convention (see QuizDocumentExtractionService's doc comment) down to
+ * plain text. Shared by both LocalQuizContentParser (deterministic pass)
+ * and CustomQuizParsingService (AI pass) so a stray/unmatched marker - e.g.
+ * one half of an underline that got split across two options by an
+ * upstream extraction quirk - is scrubbed the same way regardless of which
+ * parser ends up handling the document, instead of only being caught by
+ * whichever one happens to run.
+ */
+class QuizMarkupStripper
+{
+  public static function strip(string $text): string
+  {
+    $text = preg_replace('/\*\*(.+?)\*\*/us', '$1', $text);
+    $text = preg_replace('/<u>(.+?)<\/u>/us', '$1', $text);
+    $text = preg_replace('/<mark>(.+?)<\/mark>/us', '$1', $text);
+    $text = preg_replace('/__(.+?)__/us', '$1', $text);
+    // Safety net: a marker pair split across two options by an upstream
+    // extraction quirk (e.g. an underline spanning a paragraph/line break)
+    // leaves one half unmatched here - strip any leftover lone open/close
+    // tag rather than showing it as literal text to quiz-takers.
+    $text = preg_replace('/<\/?u>|<\/?mark>/u', '', $text);
+    $text = preg_replace('/\*\*|__/u', '', $text);
+    return $text;
+  }
+}


### PR DESCRIPTION
Follow-up to #42. The stray-marker safety net only covered LocalQuizContentParser - documents malformed enough to trigger the CustomQuizParsingService (AI) fallback still leaked literal `<u>`/`</u>` into stored questions. Extracted the cleanup into a shared `QuizMarkupStripper` used by both parsers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)